### PR TITLE
fix: margin removed from logo on mobile devices

### DIFF
--- a/onlyoffice_odoo/static/src/css/res_config_settings_views.css
+++ b/onlyoffice_odoo/static/src/css/res_config_settings_views.css
@@ -31,10 +31,6 @@
 }
 
 @media (max-width: 767px) {
-    .onlyoffice_link_pane {
-        margin-left: 0;
-    }
-
     .onlyoffice_link_container {
         width: 345px;
         height: 169px;


### PR DESCRIPTION
Fixed logo display in settings on mobile devices
![изображение](https://github.com/ONLYOFFICE/onlyoffice_odoo/assets/51357619/4514e216-ae06-465a-b904-5f9628896c48)
