### PR TITLE
Fix/url validation

### DIFF
--- a/onlyoffice_odoo/controllers/controllers.py
+++ b/onlyoffice_odoo/controllers/controllers.py
@@ -34,17 +34,6 @@ class Onlyoffice_Connector(http.Controller):
             ("Content-Type", "text/plain"),
             ("Content-Disposition", "attachment; filename=test.txt")
         ]
-
-        if jwt_utils.is_jwt_enabled(request.env):
-            token = request.httprequest.headers.get(config_utils.get_jwt_header(request.env))
-            if token:
-                token = token[len("Bearer "):]
-
-            if not token:
-                raise Exception("expected JWT")
-
-            jwt_utils.decode_token(request.env, token)
-
         response = request.make_response(content, headers)
         return response
 

--- a/onlyoffice_odoo/utils/validation_utils.py
+++ b/onlyoffice_odoo/utils/validation_utils.py
@@ -14,8 +14,7 @@ def valid_url(url):
     ip_pattern = "^([0-9]{1,3}\.){3}[0-9]{1,3}$"
     no_protocol_pattern = "^(http|https):\/\/[0-9A-z.]+.[0-9A-z.]+(|\/)$"
     patterns = [
-        "^https:\/\/[0-9A-z.]+.[0-9A-z.]+.[a-z]+$",
-        "^http:\/\/[0-9A-z.]+.[0-9A-z.]+.[a-z]+$",
+        "^(https?:\/\/)?([\w-]{1,32}\.[\w-]{1,32}((\.[\w-]{1,32})*)?)[\/\w-]*$",
         ip_pattern,
         no_protocol_pattern,
     ]


### PR DESCRIPTION
Allowed additional segments in URL, for example: https://example.com/documentserver/ , and removed the JWT check in the ConvertService check, because the connection and JWT check is done in the previous step and it also interferes with the conversion check with JWT disabled.