### PR TITLE
fix: icon size in the search field in the editor

### DIFF
--- a/onlyoffice_odoo_templates/static/src/css/onlyoffice_editor.scss
+++ b/onlyoffice_odoo_templates/static/src/css/onlyoffice_editor.scss
@@ -65,9 +65,11 @@
           }
 
           button {
+            display: flex;
             position: absolute;
             top: 0;
             right: 0;
+            align-items: center;
             border: none;
             height: 100%;
             background-color: transparent;
@@ -77,8 +79,8 @@
                 fill: var(--gray-900);
               }
 
-              width: 100%;
-              height: 100%;
+              width: 14px;
+              height: 14px;
             }
           }
         }


### PR DESCRIPTION
icon size is displayed correctly in all browsers
![изображение](https://github.com/ONLYOFFICE/onlyoffice_odoo/assets/51357619/f90e0c2f-5463-4e04-a5af-a42db8005a43)
