### PR TITLE
fix: missing security model access for onlyoffice_odoo

### DIFF
--- a/onlyoffice_odoo/__manifest__.py
+++ b/onlyoffice_odoo/__manifest__.py
@@ -11,6 +11,7 @@
     "external_dependencies": {"python": ["pyjwt"]},
     # always loaded
     "data": [
+        "security/ir.model.access.csv",
         "views/templates.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/onlyoffice_odoo/security/ir.model.access.csv
+++ b/onlyoffice_odoo/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_onlyoffice_odoo,onlyoffice.odoo,model_onlyoffice_odoo,base.group_user,1,1,1,1


### PR DESCRIPTION
This fix the warning
```
odoo.modules.loading: The models ['onlyoffice.odoo'] have no access rules in module onlyoffice_odoo, consider adding some, like:
id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
onlyoffice_odoo.access_onlyoffice_odoo,access_onlyoffice_odoo,onlyoffice_odoo.model_onlyoffice_odoo,base.group_user,1,0,0,0
```