### PR TITLE
WIP 18.0 replace documents by DMS

### DIFF
--- a/onlyoffice_odoo/__manifest__.py
+++ b/onlyoffice_odoo/__manifest__.py
@@ -11,6 +11,7 @@
     "external_dependencies": {"python": ["pyjwt"]},
     # always loaded
     "data": [
+        "security/ir.model.access.csv",
         "views/templates.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/onlyoffice_odoo/security/ir.model.access.csv
+++ b/onlyoffice_odoo/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_onlyoffice_odoo,onlyoffice.odoo,model_onlyoffice_odoo,base.group_user,1,1,1,1

--- a/onlyoffice_odoo_documents/__manifest__.py
+++ b/onlyoffice_odoo_documents/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "https://github.com/ONLYOFFICE/onlyoffice_odoo",
     "category": "Productivity",
     "version": "5.2.1",
-    "depends": ["onlyoffice_odoo", "documents"],
+    "depends": ["onlyoffice_odoo", "dms"],
     # always loaded
     "data": [
         "security/ir.model.access.csv",

--- a/onlyoffice_odoo_documents/controllers/controllers.py
+++ b/onlyoffice_odoo_documents/controllers/controllers.py
@@ -17,7 +17,8 @@ from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.tools.translate import _
 
-from odoo.addons.documents.controllers.documents import ShareRoute
+from odoo.addons.portal.controllers.portal import CustomerPortal
+from werkzeug.exceptions import NotFound
 from odoo.addons.onlyoffice_odoo.controllers.controllers import Onlyoffice_Connector
 from odoo.addons.onlyoffice_odoo.utils import config_utils, file_utils, jwt_utils, url_utils
 
@@ -47,7 +48,7 @@ class OnlyofficeDocuments_Connector(http.Controller):
                 "folder_id": int(folder_id),
             }
 
-            document = request.env["documents.document"].create(data)
+            document = request.env["dms.file"].create(data)
             request.env["onlyoffice.odoo.documents.access"].create(
                 {
                     "document_id": document.id,
@@ -73,22 +74,23 @@ class OnlyofficeDocuments_Connector(http.Controller):
 
 
 class OnlyofficeDocuments_Inherited_Connector(Onlyoffice_Connector):
-    @http.route(["/onlyoffice/documents/share/<access_token>/"], type="http", auth="public")
-    def render_shared_document_editor(self, access_token=None):
-        try:
-            document = ShareRoute._from_access_token(access_token, skip_log=True)
+    @http.route(["/onlyoffice/dms/share/<string:model>/<int:res_id>/<access_token>/"], type="http", auth="public",
+                website=True)
+    def render_shared_dms_editor(self, model, res_id, access_token=None):
+      try:
+        item = self._dms_check_access(model, res_id, access_token=access_token)
 
-            if not document or not document.exists():
-                raise request.not_found()
+        if not document or not document.exists():
+          raise request.not_found()
 
-            return request.render(
-                "onlyoffice_odoo.onlyoffice_editor", self.prepare_share_editor(document, access_token)
-            )
+        return request.render(
+          "onlyoffice_odoo.onlyoffice_editor", self.prepare_share_editor(document, access_token)
+        )
 
-        except Exception:
-            _logger.error("Ffailed to open shared document")
+      except Exception:
+        _logger.error("Failed to open shared document")
 
-        return request.not_found()
+      return request.not_found()
 
     @http.route("/onlyoffice/editor/document/<int:document_id>", auth="public", type="http", website=True)
     def render_document_editor(self, document_id, access_token=None):
@@ -97,7 +99,7 @@ class OnlyofficeDocuments_Inherited_Connector(Onlyoffice_Connector):
         )
 
     def prepare_document_editor(self, document_id, access_token):
-        document = request.env["documents.document"].browse(int(document_id))
+        document = request.env["dms.file"].browse(int(document_id))
         if document.is_locked and document.lock_uid.id != request.env.user.id:
             _logger.error("Document is locked by another user")
             raise Forbidden()
@@ -255,7 +257,7 @@ class OnlyofficeDocuments_Inherited_Connector(Onlyoffice_Connector):
             if (status == 2) | (status == 3):  # mustsave, corrupted
                 file_url = url_utils.replace_public_url_to_internal(request.env, body.get("url"))
                 datas = base64.encodebytes(urlopen(file_url, timeout=120).read())
-                document = request.env["documents.document"].sudo().browse(int(attachment.res_id))
+                document = request.env["dms.file"].sudo().browse(int(attachment.res_id))
                 document.with_user(user).sudo().write(
                     {
                         "name": attachment.name,
@@ -274,30 +276,30 @@ class OnlyofficeDocuments_Inherited_Connector(Onlyoffice_Connector):
             status=500 if response_json["error"] == 1 else 200,
             headers=[("Content-Type", "application/json")],
         )
-
-
-class OnlyOfficeShareRoute(ShareRoute):
-    @http.route("/documents/<access_token>", type="http", auth="public")
-    def documents_home(self, access_token):
-        response = super(OnlyOfficeShareRoute, self).documents_home(access_token)  # noqa: UP008
-
-        document_sudo = self._from_access_token(access_token)
-
-        if not request.env.user._is_public() or not hasattr(response, "qcontext"):
-            return
-
-        qcontext = response.qcontext
-
-        if document_sudo.type == "binary" and document_sudo.attachment_id:
-            can_view = file_utils.can_view(document_sudo.name)
-            if can_view:
-                qcontext["onlyoffice_supported"] = True
-
-        if document_sudo.type == "folder":
-            data = []
-            sub_documents_sudo = ShareRoute._get_folder_children(document_sudo)
-            for document in sub_documents_sudo:
-                data.append({"document": document, "onlyoffice_supported": file_utils.can_view(document.name)})
-            qcontext["onlyoffice_supported"] = data
-
-        return response
+#
+#
+# class OnlyOfficeShareRoute(ShareRoute):
+#     @http.route("/documents/<access_token>", type="http", auth="public")
+#     def documents_home(self, access_token):
+#         response = super(OnlyOfficeShareRoute, self).documents_home(access_token)  # noqa: UP008
+#
+#         document_sudo = self._from_access_token(access_token)
+#
+#         if not request.env.user._is_public() or not hasattr(response, "qcontext"):
+#             return
+#
+#         qcontext = response.qcontext
+#
+#         if document_sudo.type == "binary" and document_sudo.attachment_id:
+#             can_view = file_utils.can_view(document_sudo.name)
+#             if can_view:
+#                 qcontext["onlyoffice_supported"] = True
+#
+#         if document_sudo.type == "folder":
+#             data = []
+#             sub_documents_sudo = ShareRoute._get_folder_children(document_sudo)
+#             for document in sub_documents_sudo:
+#                 data.append({"document": document, "onlyoffice_supported": file_utils.can_view(document.name)})
+#             qcontext["onlyoffice_supported"] = data
+#
+#         return response

--- a/onlyoffice_odoo_documents/models/__init__.py
+++ b/onlyoffice_odoo_documents/models/__init__.py
@@ -1,4 +1,4 @@
-from . import documents
+from . import dms_file
 from . import ir_attachment
 from . import onlyoffice_odoo_documents
 from . import onlyoffice_documents_access

--- a/onlyoffice_odoo_documents/models/dms_file.py
+++ b/onlyoffice_odoo_documents/models/dms_file.py
@@ -1,8 +1,8 @@
 from odoo import _, api, models
 
 
-class Document(models.Model):
-    _inherit = "documents.document"
+class DMSFile(models.Model):
+    _inherit = "dms.file"
 
     @api.depends("checksum")
     def _compute_thumbnail(self):

--- a/onlyoffice_odoo_documents/models/onlyoffice_documents_access.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_documents_access.py
@@ -5,7 +5,7 @@ class OnlyofficeDocumentsAccessUser(models.Model):
     _name = "onlyoffice.odoo.documents.access"
     _description = "ONLYOFFICE Documents Access"
 
-    document_id = fields.Many2one("documents.document", required=True, ondelete="cascade")
+    document_id = fields.Many2one("dms.file", required=True, ondelete="cascade")
     internal_users = fields.Selection(
         [
             ("none", _("None")),

--- a/onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py
@@ -5,7 +5,7 @@ class OnlyofficeDocumentsAccessUser(models.Model):
     _name = "onlyoffice.odoo.documents.access.user"
     _description = "ONLYOFFICE Documents Access Users"
 
-    document_id = fields.Many2one("documents.document", required=True, ondelete="cascade")
+    document_id = fields.Many2one("dms.file", required=True, ondelete="cascade")
     user_id = fields.Many2one("res.partner", required=True, string="User")
     role = fields.Selection(
         [

--- a/onlyoffice_odoo_documents/models/onlyoffice_odoo_documents.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_odoo_documents.py
@@ -49,7 +49,7 @@ class OnlyofficeDocuments(models.Model):
             raise AccessError(_("No document selected for sharing."))
 
         is_admin = self.env.user.has_group("base.group_system")
-        document = self.env["documents.document"].browse(document_id)
+        document = self.env["dms.file"].browse(document_id)
         if not is_admin and document.create_uid != self.env.user:
             raise AccessError(_("Only the owner or administrator can share documents."))
 

--- a/onlyoffice_odoo_documents/views/onlyoffice_templates_share.xml
+++ b/onlyoffice_odoo_documents/views/onlyoffice_templates_share.xml
@@ -5,7 +5,7 @@
       <a
         t-if="onlyoffice_supported"
         class="btn btn-secondary rounded-pill mt-2"
-        t-att-href="'/onlyoffice/documents/share/' + document.access_token"
+        t-att-href="'/onlyoffice/dms/share/dms.file/' + str(document.id) + '/' + document.access_token + '/'"
         target="_blank"
       >
         <img
@@ -32,7 +32,7 @@
       <t t-if="is_supported">
         <div class="o_card_right d-flex flex-column flex-nowrap justify-content-end text-end me-1">
           <a
-            t-att-href="'/onlyoffice/documents/share/' + document.access_token"
+            t-att-href="'/onlyoffice/dms/share/dms.file/' + str(document.id) + '/' + document.access_token + '/'"
             title="Open in ONLYOFFICE"
             target="_blank"
           >


### PR DESCRIPTION
The module documents is not accessible, we cannot understand how it works, but the replacement solution is to use the module DMS from https://github.com/OCA/dms/tree/18.0/dms

Check issue #34 

This is a work in progress, it's not working. It's an invitation for the community to contribute.