### PR TITLE
fix: guard against IndexError when document not found in action_update_access_rights

### DIFF
--- a/onlyoffice_odoo_documents/models/documents.py
+++ b/onlyoffice_odoo_documents/models/documents.py
@@ -113,6 +113,8 @@ class Document(models.Model):
 
         specification = self._permission_specification()
         records = self.sudo().with_context(active_test=False).web_search_read([("id", "=", self.id)], specification)
+        if not records["records"]:
+            return result
         record = records["records"][0]
 
         user_accesses = []


### PR DESCRIPTION
When documents_sign calls action_update_access_rights after signing completes, the document may no longer be returned by web_search_read (e.g. it has been archived or moved by the sign flow). Accessing records['records'][0] without checking the list length raises an IndexError, breaking the sign completion.

Add an early return if web_search_read returns no records.