### PR TITLE
Fix invalid ONLYOFFICE JWT timestamps on non-UTC timezones

### DIFF
--- a/onlyoffice_odoo/utils/jwt_utils.py
+++ b/onlyoffice_odoo/utils/jwt_utils.py
@@ -16,7 +16,7 @@ def is_jwt_enabled(env):
 def encode_payload(env, payload, secret=None):
     if secret is None:
         secret = config_utils.get_jwt_secret(env)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     exp = now + datetime.timedelta(hours=24)
     payload["iat"] = int(now.timestamp())
     payload["exp"] = int(exp.timestamp())


### PR DESCRIPTION
Summary:
JWT timestamps generated by onlyoffice_odoo are incorrect on non-UTC systems.

Root cause:
The module uses datetime.utcnow() and then converts that naive datetime with timestamp(). In Python, timestamp() interprets naive datetimes as local time. That means a naive UTC value is converted incorrectly on hosts whose local timezone is not UTC. 

Impact:
On systems running in timezones such as America/Argentina/Buenos_Aires (UTC-3), the generated iat claim is shifted into the future. PyJWT then rejects the token with "The token is not yet valid (iat)". This breaks ONLYOFFICE file access and editor callbacks. 

Resolution:
Replace naive UTC datetimes with timezone-aware UTC datetimes:

    datetime.datetime.now(datetime.timezone.utc)

This produces correct iat/exp claims regardless of the server timezone.

Detail
Dirección de ONLYOFFICE Docs:
https://docs.odoo.lan/

Clave secreta de ONLYOFFICE Docs:
123456XXXXXX.......

Encabezado JWT:
Authorization

Dirección de ONLYOFFICE Docs para solicitudes internas desde el servidor:
https://odoo.lan/

Dirección del servidor para solicitudes internas de ONLYOFFICE Docs:
https://docs.odoo.lan/

When I attach a file (Excel, Word, PDF, etc.), for example, in the res_partner template, I see the OnlyOffice icon above the attachment. When I click it, another tab opens and OnlyOffice starts loading, but a pop-up error message appears saying, "The document could not be saved. Please check your connection settings or contact your administrator. Clicking the OK button will prompt you to download the document." Then, clicking again displays another pop-up error saying, "Download error." Click OK to return to the document list.

I'm sharing the log with you.
```
odoo  | 2026-04-13 22:24:34,508 30 INFO db1 odoo.addons.onlyoffice_odoo.controllers.controllers: get_user_from_token 
odoo  | 2026-04-13 22:24:34,508 30 ERROR db1 odoo.http: Exception during request handling. 
odoo  | Traceback (most recent call last):
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2825, in __call__
odoo  |     response = request._serve_db()
odoo  |                ^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2300, in _serve_db
odoo  |     raise self._update_served_exception(exc)
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2298, in _serve_db
odoo  |     return service_model.retrying(serve_func, env=self.env)
odoo  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 188, in retrying
odoo  |     result = func()
odoo  |              ^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2353, in _serve_ir_http
odoo  |     response = self.dispatcher.dispatch(rule.endpoint, args)
odoo  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2475, in dispatch
odoo  |     return self.request.registry['ir.http']._dispatch(endpoint)
odoo  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 355, in _dispatch
odoo  |     result = endpoint(**request.params)
odoo  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 808, in route_wrapper
odoo  |     result = endpoint(self, *args, **params_ok)
odoo  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/mnt/extra-addons/onlyoffice_odoo/controllers/controllers.py", line 144, in get_file_content
odoo  |     attachment = self.get_attachment(attachment_id, self.get_user_from_token(oo_security_token))
odoo  |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/mnt/extra-addons/onlyoffice_odoo/controllers/controllers.py", line 426, in get_user_from_token
odoo  |     user_id = jwt_utils.decode_token(request.env, token, config_utils.get_internal_jwt_secret(request.env))["id"]
odoo  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/mnt/extra-addons/onlyoffice_odoo/utils/jwt_utils.py", line 29, in decode_token
odoo  |     return jwt.decode(token, secret, algorithms=["HS256"])
odoo  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 210, in decode
odoo  |     decoded = self.decode_complete(
odoo  |               ^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 162, in decode_complete
odoo  |     self._validate_claims(
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 242, in _validate_claims
odoo  |     self._validate_iat(payload, now, leeway)
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 276, in _validate_iat
odoo  |     raise ImmatureSignatureError("The token is not yet valid (iat)")
odoo  | jwt.exceptions.ImmatureSignatureError: The token is not yet valid (iat)
odoo  | 2026-04-13 22:24:34,510 30 INFO db1 werkzeug: 172.18.0.6 - - [13/Apr/2026 22:24:34] "GET /onlyoffice/file/content/574?oo_security_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiaWF0IjoxNzc2MTQwNjcxLCJleHAiOjE3NzYyMjcwNzF9.VDKzg9q8fG6MnTQeM4v5SFyWM6pGSzP7pRs9aBpLNt8&shardkey=574bc3cf9a0e99333f020476ee551a6190ca2c740c1 HTTP/1.1" 500 - 7 0.003 0.019
odoo  | 2026-04-13 22:24:35,536 33 WARNING db1 odoo.http: <function odoo.addons.onlyoffice_odoo.controllers.controllers.get_file_content> called ignoring args {'shardkey'} 
odoo  | 2026-04-13 22:24:35,537 33 INFO db1 odoo.addons.onlyoffice_odoo.controllers.controllers: GET /onlyoffice/file/content/574 
odoo  | 2026-04-13 22:24:35,537 33 INFO db1 odoo.addons.onlyoffice_odoo.controllers.controllers: get_user_from_token 
odoo  | 2026-04-13 22:24:35,537 33 ERROR db1 odoo.http: Exception during request handling. 
odoo  | Traceback (most recent call last):
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2825, in __call__
odoo  |     response = request._serve_db()
odoo  |                ^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2300, in _serve_db
odoo  |     raise self._update_served_exception(exc)
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2298, in _serve_db
odoo  |     return service_model.retrying(serve_func, env=self.env)
odoo  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 188, in retrying
odoo  |     result = func()
odoo  |              ^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2353, in _serve_ir_http
odoo  |     response = self.dispatcher.dispatch(rule.endpoint, args)
odoo  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2475, in dispatch
odoo  |     return self.request.registry['ir.http']._dispatch(endpoint)
odoo  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 355, in _dispatch
odoo  |     result = endpoint(**request.params)
odoo  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/odoo/http.py", line 808, in route_wrapper
odoo  |     result = endpoint(self, *args, **params_ok)
odoo  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/mnt/extra-addons/onlyoffice_odoo/controllers/controllers.py", line 144, in get_file_content
odoo  |     attachment = self.get_attachment(attachment_id, self.get_user_from_token(oo_security_token))
odoo  |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/mnt/extra-addons/onlyoffice_odoo/controllers/controllers.py", line 426, in get_user_from_token
odoo  |     user_id = jwt_utils.decode_token(request.env, token, config_utils.get_internal_jwt_secret(request.env))["id"]
odoo  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/mnt/extra-addons/onlyoffice_odoo/utils/jwt_utils.py", line 29, in decode_token
odoo  |     return jwt.decode(token, secret, algorithms=["HS256"])
odoo  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 210, in decode
odoo  |     decoded = self.decode_complete(
odoo  |               ^^^^^^^^^^^^^^^^^^^^^
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 162, in decode_complete
odoo  |     self._validate_claims(
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 242, in _validate_claims
odoo  |     self._validate_iat(payload, now, leeway)
odoo  |   File "/usr/lib/python3/dist-packages/jwt/api_jwt.py", line 276, in _validate_iat
odoo  |     raise ImmatureSignatureError("The token is not yet valid (iat)")
odoo  | jwt.exceptions.ImmatureSignatureError: The token is not yet valid (iat)
odoo  | 2026-04-13 22:24:35,538 33 INFO db1 werkzeug: 172.18.0.6 - - [13/Apr/2026 22:24:35] "GET /onlyoffice/file/content/574?oo_security_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiaWF0IjoxNzc2MTQwNjcxLCJleHAiOjE3NzYyMjcwNzF9.VDKzg9q8fG6MnTQeM4v5SFyWM6pGSzP7pRs9aBpLNt8&shardkey=574bc3cf9a0e99333f020476ee551a6190ca2c740c1 HTTP/1.1" 500 - 6 0.003 0.019
odoo  | 2026-04-13 22:27:01,226 31 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /odoo/action-343/3/action-344/7 HTTP/1.1" 200 - 20 0.005 0.014
odoo  | 2026-04-13 22:27:01,230 33 WARNING db1 odoo.http: <function odoo.addons.onlyoffice_odoo.controllers.controllers.editor_callback> called ignoring args {'shardkey'} 
odoo  | 2026-04-13 22:27:01,230 33 INFO db1 odoo.addons.onlyoffice_odoo.controllers.controllers: POST /onlyoffice/editor/callback/574 
odoo  | 2026-04-13 22:27:01,230 33 INFO db1 odoo.addons.onlyoffice_odoo.controllers.controllers: get_user_from_token 
odoo  | 2026-04-13 22:27:01,230 33 ERROR db1 odoo.addons.onlyoffice_odoo.controllers.controllers: POST /onlyoffice/editor/callback/574 - error: The token is not yet valid (iat) 
odoo  | 2026-04-13 22:27:01,231 33 INFO db1 werkzeug: 172.18.0.6 - - [13/Apr/2026 22:27:01] "POST /onlyoffice/editor/callback/574?oo_security_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiaWF0IjoxNzc2MTQwNjcxLCJleHAiOjE3NzYyMjcwNzF9.VDKzg9q8fG6MnTQeM4v5SFyWM6pGSzP7pRs9aBpLNt8&shardkey=574bc3cf9a0e99333f020476ee551a6190ca2c740c1 HTTP/1.1" 500 - 7 0.003 0.019
odoo  | 2026-04-13 22:27:01,601 36 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/manifest.webmanifest HTTP/1.1" 200 - 13 0.004 0.008
odoo  | 2026-04-13 22:27:01,619 30 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/webclient/load_menus HTTP/1.1" 200 - 16 0.005 0.015
odoo  | 2026-04-13 22:27:01,742 30 INFO ? werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /onlyoffice_odoo/static/assets/document_formats/onlyoffice-docs-formats.json HTTP/1.1" 200 - 0 0.000 0.001
odoo  | 2026-04-13 22:27:01,814 30 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/webclient/translations?hash=dfdd1d9f2e8bcc5d322693ce5dd78fabbf6b60db&lang=es_AR HTTP/1.1" 200 - 1 0.000 0.028
odoo  | 2026-04-13 22:27:01,856 30 INFO ? werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/static/img/spin.svg HTTP/1.1" 200 - 0 0.000 0.001
odoo  | 2026-04-13 22:27:01,883 30 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/image?model=res.users&field=avatar_128&id=2 HTTP/1.1" 200 - 15 0.005 0.012
odoo  | 2026-04-13 22:27:01,887 30 INFO ? werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/static/lib/odoo_ui_icons/fonts/odoo_ui_icons.woff2 HTTP/1.1" 200 - 0 0.000 0.001
odoo  | 2026-04-13 22:27:01,888 36 INFO ? werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "GET /web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff2?v=4.7.0 HTTP/1.1" 200 - 0 0.000 0.001
odoo  | 2026-04-13 22:27:01,893 36 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "POST /web/dataset/call_kw/document.page/read#document.page.read HTTP/1.1" 200 - 2 0.001 0.002
odoo  | 2026-04-13 22:27:01,910 36 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "POST /web/dataset/call_kw/document.page/web_read#document.page.web_read HTTP/1.1" 200 - 8 0.002 0.006
odoo  | 2026-04-13 22:27:01,911 32 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "POST /mail/data HTTP/1.1" 200 - 56 0.015 0.029
odoo  | 2026-04-13 22:27:01,932 33 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "POST /web/dataset/call_kw/document.page/get_views#document.page.get_views HTTP/1.1" 200 - 41 0.013 0.031
odoo  | 2026-04-13 22:27:01,977 33 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:01] "POST /html_editor/get_ice_servers HTTP/1.1" 200 - 2 0.001 0.002
odoo  | 2026-04-13 22:27:02,009 31 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:02] "POST /mail/thread/messages HTTP/1.1" 200 - 18 0.004 0.010
odoo  | 2026-04-13 22:27:02,037 33 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:02] "POST /mail/data HTTP/1.1" 200 - 48 0.015 0.030
odoo  | 2026-04-13 22:27:02,076 33 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:02] "GET /web/bundle/web.assets_emoji?lang=es_AR&debug=1 HTTP/1.1" 200 - 1 0.000 0.001
odoo  | 2026-04-13 22:27:02,237 30 INFO db1 werkzeug: 192.168.100.27 - - [13/Apr/2026 22:27:02] "GET /web/service-worker.js HTTP/1.1" 200 - 1 0.001 0.002
```

this command timedatectl returns:
```
               Local time: Mon 2026-04-13 22:42:42 -03
           Universal time: Tue 2026-04-14 01:42:42 UTC
                 RTC time: Tue 2026-04-14 01:42:42
                Time zone: America/Argentina/Buenos_Aires (-03, -0300)
System clock synchronized: yes
              NTP service: active
          RTC in local TZ: no
```

this command docker exec onlyoffice_docs date -Is returns::
`2026-04-13T22:43:13-03:00`

this command
docker exec -i odoo python3 - <<'PY'
```
import time, datetime
from datetime import timezone
print("time.time() =", time.time())
print("datetime.now() =", datetime.datetime.now())
print("datetime.utcnow() =", datetime.datetime.utcnow())
print("datetime.now(timezone.utc) =", datetime.datetime.now(timezone.utc))
PY
returns:
<stdin>:5: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
time.time() = 1776131035.3955019
datetime.now() = 2026-04-13 22:43:55.395510
datetime.utcnow() = 2026-04-14 01:43:55.400867
datetime.now(timezone.utc) = 2026-04-14 01:43:55.400875+00:00
```
this command docker exec -i odoo sed -n '1,120p' /mnt/extra-addons/onlyoffice_odoo/utils/jwt_utils.py returns::
```
#
# (c) Copyright Ascensio System SIA 2024
#

import datetime

import jwt

from odoo.addons.onlyoffice_odoo.utils import config_utils


def is_jwt_enabled(env):
    return bool(config_utils.get_jwt_secret(env))


def encode_payload(env, payload, secret=None):
    if secret is None:
        secret = config_utils.get_jwt_secret(env)
    now = datetime.datetime.utcnow()
    exp = now + datetime.timedelta(hours=24)
    payload["iat"] = int(now.timestamp())
    payload["exp"] = int(exp.timestamp())
    return jwt.encode(payload, secret, algorithm="HS256")


def decode_token(env, token, secret=None):
    if secret is None:
        secret = config_utils.get_jwt_secret(env)
    return jwt.decode(token, secret, algorithms=["HS256"])
```