### PR TITLE
Fix regex string to use raw string and remove unnecessary escapes.

### DIFF
--- a/onlyoffice_odoo/utils/validation_utils.py
+++ b/onlyoffice_odoo/utils/validation_utils.py
@@ -15,7 +15,7 @@ def valid_url(url):
     if not url:
         return True
     # pylint: disable=anomalous-backslash-in-string
-    pattern = "^(https?:\/\/)?[\w-]{1,32}(\.[\w-]{1,32})*[\/\w-]*(:[\d]{1,5}\/?)?$"
+    pattern = r"^(https?://)?[\w-]{1,32}(\.[\w-]{1,32})*[/\w-]*(:[\d]{1,5}/?)?$"
     # pylint: enable=anomalous-backslash-in-string
     if re.findall(pattern, url):
         return True


### PR DESCRIPTION
This avoids Python 3.12 SyntaxWarning caused by invalid escape sequences (e.g. \/, \w, \d) in normal strings, and simplifies the pattern by removing redundant escaping of /.