### PR TITLE
Timezone / Fix regex remove escapes / type json deprecated

### DIFF
--- a/onlyoffice_odoo/controllers/controllers.py
+++ b/onlyoffice_odoo/controllers/controllers.py
@@ -90,7 +90,7 @@ def onlyoffice_request(url, method, opts=None):
 
 
 class Onlyoffice_Connector(http.Controller):
-    @http.route("/onlyoffice/editor/get_config", auth="user", methods=["POST"], type="json", csrf=False)
+    @http.route("/onlyoffice/editor/get_config", auth="user", methods=["POST"], type="jsonrpc", csrf=False)
     def get_config(self, document_id=None, attachment_id=None, access_token=None):
         _logger.info("POST /onlyoffice/editor/get_config - document: %s, attachment: %s", document_id, attachment_id)
         document = None
@@ -518,7 +518,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
             _logger.error(f"API request failed to {url}: {str(e)}")
             raise UserError(f"Failed to connect to Forms API: {str(e)}") from e
 
-    @http.route("/onlyoffice/oforms/locales", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/locales", type="jsonrpc", auth="user")
     def get_oform_locales(self):
         url = self.OFORMS_URL
         endpoint = "i18n/locales"
@@ -534,7 +534,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
             ]
         }
 
-    @http.route("/onlyoffice/oforms/category-types", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/category-types", type="jsonrpc", auth="user")
     def get_category_types(self, locale="en"):
         url = self.OFORMS_URL
         endpoint = "menu-translations"
@@ -564,7 +564,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
 
         return {"data": categories}
 
-    @http.route("/onlyoffice/oforms/subcategories", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/subcategories", type="jsonrpc", auth="user")
     def get_subcategories(self, category_type, locale="en"):
         url = self.OFORMS_URL
         endpoint_map = {"categorie": "categories", "type": "types", "compilation": "compilations"}
@@ -598,7 +598,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
 
         return {"data": subcategories}
 
-    @http.route("/onlyoffice/oforms", type="json", auth="user")
+    @http.route("/onlyoffice/oforms", type="jsonrpc", auth="user")
     def get_oforms(self, params=None, **kwargs):
         url = self.CMSOFORMS_URL
         if params is None:

--- a/onlyoffice_odoo/utils/jwt_utils.py
+++ b/onlyoffice_odoo/utils/jwt_utils.py
@@ -16,7 +16,7 @@ def is_jwt_enabled(env):
 def encode_payload(env, payload, secret=None):
     if secret is None:
         secret = config_utils.get_jwt_secret(env)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     exp = now + datetime.timedelta(hours=24)
     payload["iat"] = int(now.timestamp())
     payload["exp"] = int(exp.timestamp())

--- a/onlyoffice_odoo/utils/validation_utils.py
+++ b/onlyoffice_odoo/utils/validation_utils.py
@@ -15,7 +15,7 @@ def valid_url(url):
     if not url:
         return True
     # pylint: disable=anomalous-backslash-in-string
-    pattern = "^(https?:\/\/)?[\w-]{1,32}(\.[\w-]{1,32})*[\/\w-]*(:[\d]{1,5}\/?)?$"
+      pattern = r"^(https?://)?[\w-]{1,32}(\.[\w-]{1,32})*[/\w-]*(:[\d]{1,5}/?)?$"
     # pylint: enable=anomalous-backslash-in-string
     if re.findall(pattern, url):
         return True

--- a/onlyoffice_odoo/utils/validation_utils.py
+++ b/onlyoffice_odoo/utils/validation_utils.py
@@ -15,7 +15,7 @@ def valid_url(url):
     if not url:
         return True
     # pylint: disable=anomalous-backslash-in-string
-      pattern = r"^(https?://)?[\w-]{1,32}(\.[\w-]{1,32})*[/\w-]*(:[\d]{1,5}/?)?$"
+    pattern = r"^(https?://)?[\w-]{1,32}(\.[\w-]{1,32})*[/\w-]*(:[\d]{1,5}/?)?$"
     # pylint: enable=anomalous-backslash-in-string
     if re.findall(pattern, url):
         return True


### PR DESCRIPTION
Use timezone-aware UTC datetime for JWT encoding

Fix regex string to use raw string and remove unnecessary escapes.
This avoids Python 3.12 SyntaxWarning caused by invalid escape sequences (e.g. \/, \w, \d) in normal strings, and simplifies the pattern by removing redundant escaping of /.

type="json" is deprecated (Odoo 19 or later)
Updating to type="jsonrpc" ensures compatibility with current and future Odoo versions and removes deprecation warnings.