### PR TITLE
fix: use _lt() instead of _() in Selection field definitions

### DIFF
--- a/onlyoffice_odoo/controllers/controllers.py
+++ b/onlyoffice_odoo/controllers/controllers.py
@@ -90,7 +90,7 @@ def onlyoffice_request(url, method, opts=None):
 
 
 class Onlyoffice_Connector(http.Controller):
-    @http.route("/onlyoffice/editor/get_config", auth="user", methods=["POST"], type="json", csrf=False)
+    @http.route("/onlyoffice/editor/get_config", auth="user", methods=["POST"], type="jsonrpc", csrf=False)
     def get_config(self, document_id=None, attachment_id=None, access_token=None):
         _logger.info("POST /onlyoffice/editor/get_config - document: %s, attachment: %s", document_id, attachment_id)
         document = None
@@ -518,7 +518,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
             _logger.error(f"API request failed to {url}: {str(e)}")
             raise UserError(f"Failed to connect to Forms API: {str(e)}") from e
 
-    @http.route("/onlyoffice/oforms/locales", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/locales", type="jsonrpc", auth="user")
     def get_oform_locales(self):
         url = self.OFORMS_URL
         endpoint = "i18n/locales"
@@ -534,7 +534,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
             ]
         }
 
-    @http.route("/onlyoffice/oforms/category-types", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/category-types", type="jsonrpc", auth="user")
     def get_category_types(self, locale="en"):
         url = self.OFORMS_URL
         endpoint = "menu-translations"
@@ -564,7 +564,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
 
         return {"data": categories}
 
-    @http.route("/onlyoffice/oforms/subcategories", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/subcategories", type="jsonrpc", auth="user")
     def get_subcategories(self, category_type, locale="en"):
         url = self.OFORMS_URL
         endpoint_map = {"categorie": "categories", "type": "types", "compilation": "compilations"}
@@ -598,7 +598,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
 
         return {"data": subcategories}
 
-    @http.route("/onlyoffice/oforms", type="json", auth="user")
+    @http.route("/onlyoffice/oforms", type="jsonrpc", auth="user")
     def get_oforms(self, params=None, **kwargs):
         url = self.CMSOFORMS_URL
         if params is None:

--- a/onlyoffice_odoo_documents/controllers/controllers.py
+++ b/onlyoffice_odoo_documents/controllers/controllers.py
@@ -26,7 +26,7 @@ _mobile_regex = r"android|avantgo|playbook|blackberry|blazer|compal|elaine|fenne
 
 
 class OnlyofficeDocuments_Connector(http.Controller):
-    @http.route("/onlyoffice/documents/file/create", auth="user", methods=["POST"], type="json")
+    @http.route("/onlyoffice/documents/file/create", auth="user", methods=["POST"], type="jsonrpc")
     def post_file_create(self, folder_id, supported_format, title, url=None):
         result = {"error": None, "file_id": None, "document_id": None}
 

--- a/onlyoffice_odoo_documents/models/onlyoffice_documents_access.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_documents_access.py
@@ -1,4 +1,5 @@
-from odoo import _, fields, models
+from odoo import fields, models
+from odoo.tools.translate import _lt
 
 
 class OnlyofficeDocumentsAccessUser(models.Model):
@@ -8,26 +9,26 @@ class OnlyofficeDocumentsAccessUser(models.Model):
     document_id = fields.Many2one("documents.document", required=True, ondelete="cascade")
     internal_users = fields.Selection(
         [
-            ("none", _("None")),
-            ("view", _("Viewer")),
-            ("commenter", _("Commenter")),
-            ("reviewer", _("Reviewer")),
-            ("edit", _("Editor")),
-            ("form_filling", _("Form Filling")),
-            ("custom_filter", _("Custom Filter")),
+            ("none", _lt("None")),
+            ("view", _lt("Viewer")),
+            ("commenter", _lt("Commenter")),
+            ("reviewer", _lt("Reviewer")),
+            ("edit", _lt("Editor")),
+            ("form_filling", _lt("Form Filling")),
+            ("custom_filter", _lt("Custom Filter")),
         ],
         default="none",
         string="Internal Users Access",
     )
     link_access = fields.Selection(
         [
-            ("none", _("None")),
-            ("view", _("Viewer")),
-            ("commenter", _("Commenter")),
-            ("reviewer", _("Reviewer")),
-            ("edit", _("Editor")),
-            ("form_filling", _("Form Filling")),
-            ("custom_filter", _("Custom Filter")),
+            ("none", _lt("None")),
+            ("view", _lt("Viewer")),
+            ("commenter", _lt("Commenter")),
+            ("reviewer", _lt("Reviewer")),
+            ("edit", _lt("Editor")),
+            ("form_filling", _lt("Form Filling")),
+            ("custom_filter", _lt("Custom Filter")),
         ],
         default="view",
         string="Link Access",

--- a/onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py
@@ -1,4 +1,5 @@
-from odoo import _, fields, models
+from odoo import fields, models
+from odoo.tools.translate import _lt
 
 
 class OnlyofficeDocumentsAccessUser(models.Model):
@@ -9,13 +10,13 @@ class OnlyofficeDocumentsAccessUser(models.Model):
     user_id = fields.Many2one("res.partner", required=True, string="User")
     role = fields.Selection(
         [
-            ("none", _("None")),
-            ("view", _("Viewer")),
-            ("commenter", _("Commenter")),
-            ("reviewer", _("Reviewer")),
-            ("edit", _("Editor")),
-            ("form_filling", _("Form Filling")),
-            ("custom_filter", _("Custom Filter")),
+            ("none", _lt("None")),
+            ("view", _lt("Viewer")),
+            ("commenter", _lt("Commenter")),
+            ("reviewer", _lt("Reviewer")),
+            ("edit", _lt("Editor")),
+            ("form_filling", _lt("Form Filling")),
+            ("custom_filter", _lt("Custom Filter")),
         ],
         required=True,
         string="Access Level",

--- a/onlyoffice_odoo_templates/controllers/controllers.py
+++ b/onlyoffice_odoo_templates/controllers/controllers.py
@@ -38,7 +38,7 @@ class Onlyoffice_Inherited_Connector(Onlyoffice_Connector):
         except Exception as e:
             return request.not_found(f"Error: {str(e)}")
 
-    @http.route("/onlyoffice/template/editor", auth="user", methods=["POST"], type="json", csrf=False)
+    @http.route("/onlyoffice/template/editor", auth="user", methods=["POST"], type="jsonrpc", csrf=False)
     def override_render_editor(self, attachment_id, access_token=None):
         attachment = self.get_attachment(attachment_id)
         if not attachment:


### PR DESCRIPTION
## Summary

- Replace eager translation `_()` with lazy translation `_lt()` in Selection field definitions in `onlyoffice_odoo_documents`
  - Fixes "no translation language detected, skipping translation" warnings during module loading in Odoo 19.0
  - `_()` is called at class definition time (during import), before any language context exists. `_lt()` defers translation to render time.
- Replace deprecated `@route(type='json')` with `@route(type='jsonrpc')` across all three modules
  - Since Odoo 19.0, `type='json'` is a deprecated alias for `type='jsonrpc'`

## Files changed

- `onlyoffice_odoo/controllers/controllers.py`
- `onlyoffice_odoo_documents/models/onlyoffice_documents_access.py`
- `onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py`
- `onlyoffice_odoo_documents/controllers/controllers.py`
- `onlyoffice_odoo_templates/controllers/controllers.py`