### PR TITLE
fix: set thumbnail_status to 'client_generated' for PDFs (Odoo 19)

### DIFF
--- a/onlyoffice_odoo_documents/models/documents.py
+++ b/onlyoffice_odoo_documents/models/documents.py
@@ -11,7 +11,7 @@ class Document(models.Model):
         for record in self:
             if record.mimetype == "application/pdf":
                 record.thumbnail = False
-                record.thumbnail_status = False
+                record.thumbnail_status = "client_generated"
         return
 
     def _is_custom_role(self, role):


### PR DESCRIPTION
## Problem

In Odoo 19, `thumbnail_status = 'client_generated'` is the value that tells the browser to generate the PDF thumbnail client-side. The current code sets `thumbnail_status = False` for PDF files, which suppresses the preview entirely — the PDF thumbnail never loads in the Documents app.

## Fix

Change `thumbnail_status = False` to `thumbnail_status = "client_generated"` to match Odoo 19's expected behavior.

## Reference
https://github.com/odoo/enterprise/pull/49111
Odoo 17 introduced `client_generated` as a dedicated selection value for browser-rendered thumbnails:
```python
# documents/models/documents_document.py (Odoo 19)
elif document.mimetype.startswith('application/pdf'):
    document.thumbnail = False
    document.thumbnail_status = 'client_generated'
```