### PR TITLE
templates: cache form field keys to cut a docbuilder round-trip per fill

### DIFF
--- a/CHANGELOG templates.md
+++ b/CHANGELOG templates.md
@@ -13,6 +13,7 @@
 
 - convert PDF to PDF form
 - field value localization for report generation (date/monetary fields)
+- cache template form field keys to avoid an extra docbuilder round-trip on every fill
 
 ## 4.3.2
 

--- a/onlyoffice_odoo_templates/controllers/controllers.py
+++ b/onlyoffice_odoo_templates/controllers/controllers.py
@@ -221,7 +221,7 @@ class OnlyofficeTemplate_Connector(http.Controller):
             with file_open("onlyoffice_odoo_templates/controllers/fill_template.docbuilder", "r") as f:
                 docbuilder_script_content = f.read()
 
-            keys = self.get_keys(attachment_id, oo_security_token)
+            keys = self._get_cached_keys(template, oo_security_token)
             logger.info(
                 "GET /onlyoffice/template/callback/docbuilder/fill_template - got %s keys", len(keys) if keys else 0
             )
@@ -263,6 +263,31 @@ class OnlyofficeTemplate_Connector(http.Controller):
         except Exception as e:
             logger.warning(e)
             return request.not_found()
+
+    def _get_cached_keys(self, template, oo_security_token):
+        """Return the template's OFORM field keys, using the value cached on the
+        template when it is still valid.
+
+        The keys are derived solely from the template PDF, so we key the cache on
+        the attachment checksum: when the PDF changes (re-upload, conversion,
+        editor save) the checksum changes and the keys are recomputed. Reusing the
+        cache avoids the synchronous docbuilder round-trip in ``get_keys`` that
+        would otherwise pin an additional HTTP worker for the whole fill.
+        """
+        checksum = template.attachment_id.checksum
+        if template.field_keys:
+            try:
+                cached = json.loads(template.field_keys)
+            except (ValueError, TypeError):
+                cached = None
+            if cached and cached.get("checksum") == checksum:
+                logger.info("_get_cached_keys - cache hit for template %s", template.id)
+                return cached.get("keys")
+
+        keys = self.get_keys(template.attachment_id.id, oo_security_token)
+        template.sudo().write({"field_keys": json.dumps({"checksum": checksum, "keys": keys})})
+        logger.info("_get_cached_keys - cache refreshed for template %s", template.id)
+        return keys
 
     def get_keys(self, attachment_id, oo_security_token):
         logger.info("get_keys - attachment: %s", attachment_id)

--- a/onlyoffice_odoo_templates/models/onlyoffice_odoo_templates.py
+++ b/onlyoffice_odoo_templates/models/onlyoffice_odoo_templates.py
@@ -34,6 +34,12 @@ class OnlyOfficeTemplate(models.Model):
     hide_file_field = fields.Boolean(string="Hide File Field", default=False)
     attachment_id = fields.Many2one("ir.attachment", readonly=True)
     mimetype = fields.Char(default="application/pdf")
+    # Cached OFORM field keys for the template PDF. The keys depend only on the
+    # attachment contents (not on the records being filled), so we cache them to
+    # avoid an extra synchronous docbuilder round-trip on every fill. Stored as
+    # JSON {"checksum": <attachment.checksum>, "keys": [...]} so the cache is
+    # transparently invalidated whenever the underlying PDF changes.
+    field_keys = fields.Text(string="Cached form field keys", readonly=True, copy=False)
     report_id = fields.Many2one("ir.actions.report", string="Related Report", copy=False)
 
     @api.onchange("name")

--- a/onlyoffice_odoo_templates/tests/__init__.py
+++ b/onlyoffice_odoo_templates/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2026 Ascensio System SIA
+from . import test_field_keys_cache

--- a/onlyoffice_odoo_templates/tests/test_field_keys_cache.py
+++ b/onlyoffice_odoo_templates/tests/test_field_keys_cache.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Ascensio System SIA
+import base64
+import json
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.onlyoffice_odoo_templates.controllers.controllers import OnlyofficeTemplate_Connector
+
+
+class TestFieldKeysCache(TransactionCase):
+    """The OFORM field keys depend only on the template PDF, so they are cached
+    on the template (keyed by attachment checksum) to avoid an extra synchronous
+    docbuilder round-trip on every fill. See ``_get_cached_keys``.
+    """
+
+    def setUp(self):
+        super().setUp()
+        model = self.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
+        self.template = self.env["onlyoffice.odoo.templates"].create(
+            {
+                "name": "Test template",
+                "template_model_id": model.id,
+            }
+        )
+        self.controller = OnlyofficeTemplate_Connector()
+
+    def test_keys_are_computed_then_cached(self):
+        with patch.object(OnlyofficeTemplate_Connector, "get_keys", return_value=["a", "b"]) as mock_get_keys:
+            # First call: cache empty -> compute via get_keys and store.
+            keys = self.controller._get_cached_keys(self.template, "token")
+            self.assertEqual(keys, ["a", "b"])
+            self.assertEqual(mock_get_keys.call_count, 1)
+
+            cached = json.loads(self.template.field_keys)
+            self.assertEqual(cached["keys"], ["a", "b"])
+            self.assertEqual(cached["checksum"], self.template.attachment_id.checksum)
+
+            # Second call: same PDF -> cache hit, get_keys not called again.
+            keys = self.controller._get_cached_keys(self.template, "token")
+            self.assertEqual(keys, ["a", "b"])
+            self.assertEqual(mock_get_keys.call_count, 1)
+
+    def test_cache_invalidated_when_pdf_changes(self):
+        with patch.object(OnlyofficeTemplate_Connector, "get_keys", return_value=["a"]) as mock_get_keys:
+            self.controller._get_cached_keys(self.template, "token")
+            self.assertEqual(mock_get_keys.call_count, 1)
+
+        # Changing the underlying PDF changes the attachment checksum, which must
+        # invalidate the cache and trigger a recompute.
+        self.template.attachment_id.write({"datas": base64.b64encode(b"%PDF-1.4 different contents")})
+
+        with patch.object(OnlyofficeTemplate_Connector, "get_keys", return_value=["a", "c"]) as mock_get_keys:
+            keys = self.controller._get_cached_keys(self.template, "token")
+            self.assertEqual(keys, ["a", "c"])
+            self.assertEqual(mock_get_keys.call_count, 1)
+            self.assertEqual(json.loads(self.template.field_keys)["keys"], ["a", "c"])
+
+    def test_corrupt_cache_is_recomputed(self):
+        # A non-JSON value must not break filling; it should just recompute.
+        self.template.sudo().write({"field_keys": "not-json"})
+        with patch.object(OnlyofficeTemplate_Connector, "get_keys", return_value=["x"]) as mock_get_keys:
+            keys = self.controller._get_cached_keys(self.template, "token")
+            self.assertEqual(keys, ["x"])
+            self.assertEqual(mock_get_keys.call_count, 1)


### PR DESCRIPTION
## Problem

Filling a template is synchronously re-entrant. `main()` → `fill_template()` holds one HTTP worker for the whole build; its `fill_template` callback calls `get_keys()`, which issues **another** synchronous docbuilder `POST` whose callback (`docbuilder_get_keys`) runs in a third worker. So a single template fill pins ~3 prefork HTTP workers for its entire duration, and on instances with a low `workers` count this can self-deadlock (the build's own callbacks can't be served), surfacing as a 120 s `ReadTimeout` with no PDF.

## Change

The OFORM field keys depend **only on the template PDF**, not on the records being filled. This PR caches them on the template, keyed by the attachment checksum:

- New `field_keys` field on `onlyoffice.odoo.templates` storing `{"checksum": <attachment.checksum>, "keys": [...]}`.
- New `_get_cached_keys()` helper used by the fill callback instead of calling `get_keys()` every time.

Repeat fills reuse the cached keys and skip the extra docbuilder round-trip (**3 → 2 workers held per fill**). Because the cache is keyed on the attachment checksum, it is transparently invalidated whenever the PDF changes — re-upload, PDF→form conversion, or editor save — with no explicit invalidation hooks. The first fill after any change recomputes once.

No UX change.

## Tests

Adds `tests/test_field_keys_cache.py`:
- keys computed then cached (second fill does not call `get_keys` again),
- cache invalidated when the underlying PDF (checksum) changes,
- corrupt/non-JSON cache value falls back to recompute.

Verified on a clean Odoo 19 database: module installs (new column created) and all tests pass.