### PR TITLE
Fix Odoo 19.0 load-time warnings (jsonrpc route, model access, regex raw string)

### DIFF
--- a/onlyoffice_odoo/__manifest__.py
+++ b/onlyoffice_odoo/__manifest__.py
@@ -11,6 +11,7 @@
     "external_dependencies": {"python": ["pyjwt"]},
     # always loaded
     "data": [
+        "security/ir.model.access.csv",
         "views/templates.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/onlyoffice_odoo/controllers/controllers.py
+++ b/onlyoffice_odoo/controllers/controllers.py
@@ -90,7 +90,7 @@ def onlyoffice_request(url, method, opts=None):
 
 
 class Onlyoffice_Connector(http.Controller):
-    @http.route("/onlyoffice/editor/get_config", auth="user", methods=["POST"], type="json", csrf=False)
+    @http.route("/onlyoffice/editor/get_config", auth="user", methods=["POST"], type="jsonrpc", csrf=False)
     def get_config(self, document_id=None, attachment_id=None, access_token=None):
         _logger.info("POST /onlyoffice/editor/get_config - document: %s, attachment: %s", document_id, attachment_id)
         document = None
@@ -518,7 +518,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
             _logger.error(f"API request failed to {url}: {str(e)}")
             raise UserError(f"Failed to connect to Forms API: {str(e)}") from e
 
-    @http.route("/onlyoffice/oforms/locales", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/locales", type="jsonrpc", auth="user")
     def get_oform_locales(self):
         url = self.OFORMS_URL
         endpoint = "i18n/locales"
@@ -534,7 +534,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
             ]
         }
 
-    @http.route("/onlyoffice/oforms/category-types", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/category-types", type="jsonrpc", auth="user")
     def get_category_types(self, locale="en"):
         url = self.OFORMS_URL
         endpoint = "menu-translations"
@@ -564,7 +564,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
 
         return {"data": categories}
 
-    @http.route("/onlyoffice/oforms/subcategories", type="json", auth="user")
+    @http.route("/onlyoffice/oforms/subcategories", type="jsonrpc", auth="user")
     def get_subcategories(self, category_type, locale="en"):
         url = self.OFORMS_URL
         endpoint_map = {"categorie": "categories", "type": "types", "compilation": "compilations"}
@@ -598,7 +598,7 @@ class OnlyOfficeOFormsDocumentsController(http.Controller):
 
         return {"data": subcategories}
 
-    @http.route("/onlyoffice/oforms", type="json", auth="user")
+    @http.route("/onlyoffice/oforms", type="jsonrpc", auth="user")
     def get_oforms(self, params=None, **kwargs):
         url = self.CMSOFORMS_URL
         if params is None:

--- a/onlyoffice_odoo/security/ir.model.access.csv
+++ b/onlyoffice_odoo/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_onlyoffice_odoo_user,onlyoffice.odoo.user,model_onlyoffice_odoo,base.group_user,1,0,0,0

--- a/onlyoffice_odoo/utils/validation_utils.py
+++ b/onlyoffice_odoo/utils/validation_utils.py
@@ -14,9 +14,7 @@ from odoo.addons.onlyoffice_odoo.utils import jwt_utils
 def valid_url(url):
     if not url:
         return True
-    # pylint: disable=anomalous-backslash-in-string
-    pattern = "^(https?:\/\/)?[\w-]{1,32}(\.[\w-]{1,32})*[\/\w-]*(:[\d]{1,5}\/?)?$"
-    # pylint: enable=anomalous-backslash-in-string
+    pattern = r"^(https?://)?[\w-]{1,32}(\.[\w-]{1,32})*[/\w-]*(:[\d]{1,5}/?)?$"
     if re.findall(pattern, url):
         return True
     return False

--- a/onlyoffice_odoo_documents/controllers/controllers.py
+++ b/onlyoffice_odoo_documents/controllers/controllers.py
@@ -26,7 +26,7 @@ _mobile_regex = r"android|avantgo|playbook|blackberry|blazer|compal|elaine|fenne
 
 
 class OnlyofficeDocuments_Connector(http.Controller):
-    @http.route("/onlyoffice/documents/file/create", auth="user", methods=["POST"], type="json")
+    @http.route("/onlyoffice/documents/file/create", auth="user", methods=["POST"], type="jsonrpc")
     def post_file_create(self, folder_id, supported_format, title, url=None):
         result = {"error": None, "file_id": None, "document_id": None}
 

--- a/onlyoffice_odoo_documents/models/onlyoffice_documents_access.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_documents_access.py
@@ -1,4 +1,4 @@
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class OnlyofficeDocumentsAccessUser(models.Model):
@@ -8,26 +8,26 @@ class OnlyofficeDocumentsAccessUser(models.Model):
     document_id = fields.Many2one("documents.document", required=True, ondelete="cascade")
     internal_users = fields.Selection(
         [
-            ("none", _("None")),
-            ("view", _("Viewer")),
-            ("commenter", _("Commenter")),
-            ("reviewer", _("Reviewer")),
-            ("edit", _("Editor")),
-            ("form_filling", _("Form Filling")),
-            ("custom_filter", _("Custom Filter")),
+            ("none", "None"),
+            ("view", "Viewer"),
+            ("commenter", "Commenter"),
+            ("reviewer", "Reviewer"),
+            ("edit", "Editor"),
+            ("form_filling", "Form Filling"),
+            ("custom_filter", "Custom Filter"),
         ],
         default="none",
         string="Internal Users Access",
     )
     link_access = fields.Selection(
         [
-            ("none", _("None")),
-            ("view", _("Viewer")),
-            ("commenter", _("Commenter")),
-            ("reviewer", _("Reviewer")),
-            ("edit", _("Editor")),
-            ("form_filling", _("Form Filling")),
-            ("custom_filter", _("Custom Filter")),
+            ("none", "None"),
+            ("view", "Viewer"),
+            ("commenter", "Commenter"),
+            ("reviewer", "Reviewer"),
+            ("edit", "Editor"),
+            ("form_filling", "Form Filling"),
+            ("custom_filter", "Custom Filter"),
         ],
         default="view",
         string="Link Access",

--- a/onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py
+++ b/onlyoffice_odoo_documents/models/onlyoffice_documents_access_user.py
@@ -1,4 +1,4 @@
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class OnlyofficeDocumentsAccessUser(models.Model):
@@ -9,13 +9,13 @@ class OnlyofficeDocumentsAccessUser(models.Model):
     user_id = fields.Many2one("res.partner", required=True, string="User")
     role = fields.Selection(
         [
-            ("none", _("None")),
-            ("view", _("Viewer")),
-            ("commenter", _("Commenter")),
-            ("reviewer", _("Reviewer")),
-            ("edit", _("Editor")),
-            ("form_filling", _("Form Filling")),
-            ("custom_filter", _("Custom Filter")),
+            ("none", "None"),
+            ("view", "Viewer"),
+            ("commenter", "Commenter"),
+            ("reviewer", "Reviewer"),
+            ("edit", "Editor"),
+            ("form_filling", "Form Filling"),
+            ("custom_filter", "Custom Filter"),
         ],
         required=True,
         string="Access Level",


### PR DESCRIPTION
## Summary

On Odoo 19.0, installing/upgrading `onlyoffice_odoo` and
`onlyoffice_odoo_documents` emits three categories of load-time warnings.
This PR resolves all three (no functional/behavioral change):

- **Deprecated route type**: `@http.route(type="json")` is a deprecated
  alias for `type="jsonrpc"` since 19.0. Migrated all occurrences in
  `onlyoffice_odoo/controllers/controllers.py` (5) and
  `onlyoffice_odoo_documents/controllers/controllers.py` (1).
- **Missing access rules**: the `onlyoffice.odoo` model (with the
  `@api.model` helpers `get_demo` / `get_same_tab`, called over RPC by
  internal users) had no `ir.model.access` records, producing
  `The models ['onlyoffice.odoo'] have no access rules...`. Added
  `security/ir.model.access.csv` granting read-only access to
  `base.group_user` and registered it in the manifest.
- **SyntaxWarning**: the URL validation regex in
  `utils/validation_utils.py` used invalid escape sequences (`\/`) in a
  normal string. Converted it to a raw string, which also lets us drop
  the `pylint: disable=anomalous-backslash-in-string` pragmas.

## Test plan

- [x] `-i onlyoffice_odoo,onlyoffice_odoo_documents` on Odoo 19.0:
      modules load, all three warnings gone, no new errors.