### PR TITLE
fix: import DOCX/XLSX/PPTX documents as templates

### DIFF
--- a/CHANGELOG templates.md
+++ b/CHANGELOG templates.md
@@ -8,6 +8,7 @@
 - new type of reports "onlyoffice-pdf"
 - save filled template to documents
 - scroll to field when clicked
+- import DOCX/XLSX/PPTX documents as templates (converted to a fillable PDF on save)
 
 ## Fixed
 

--- a/onlyoffice_odoo_templates/controllers/controllers.py
+++ b/onlyoffice_odoo_templates/controllers/controllers.py
@@ -353,9 +353,10 @@ class OnlyofficeTemplate_Connector(http.Controller):
         attachment = self.get_record("ir.attachment", attachment_id, self.get_user_from_token(oo_security_token))
         if attachment:
             content = base64.b64decode(attachment.datas)
+            ext = file_utils.get_file_ext(attachment.name) or "pdf"
             headers = {
-                "Content-Type": "application/pdf",
-                "Content-Disposition": "attachment; filename=template.pdf",
+                "Content-Type": attachment.mimetype or "application/pdf",
+                "Content-Disposition": f"attachment; filename=template.{ext}",
             }
             logger.info("GET /onlyoffice/template/download - success")
             return request.make_response(content, headers)

--- a/onlyoffice_odoo_templates/models/onlyoffice_odoo_templates.py
+++ b/onlyoffice_odoo_templates/models/onlyoffice_odoo_templates.py
@@ -57,15 +57,32 @@ class OnlyOfficeTemplate(models.Model):
         if self.file and self.create_date:  # if file exist
             decode_file = base64.b64decode(self.file)
             is_pdf_form = pdf_utils.is_pdf_form(decode_file)
+            src_ext = "pdf"
+            if not is_pdf_form:
+                src_ext = pdf_utils.get_source_format(decode_file)
+                if not src_ext:
+                    self.file = False
+                    raise UserError(
+                        _("Unsupported file format. Upload a PDF form or a DOCX/XLSX/PPTX document.")
+                    )
             old_datas = self.attachment_id.datas
-            self.attachment_id.write({"datas": self.file})
+            old_name = self.attachment_id.name
+            old_mimetype = self.attachment_id.mimetype
+            # Hold the source bytes (with matching name/mimetype) while converting.
+            self.attachment_id.write(
+                {
+                    "datas": self.file,
+                    "name": self.name + "." + src_ext,
+                    "mimetype": file_utils.get_mime_by_ext(src_ext) or "application/pdf",
+                }
+            )
             self.file = False
 
             if not is_pdf_form:
                 self.env.cr.commit()
-                converted_result = self._convert_to_form(self.attachment_id)
+                converted_result = self._convert_to_form(self.attachment_id, filetype=src_ext)
                 if converted_result.get("error"):
-                    self.attachment_id.write({"datas": old_datas})
+                    self.attachment_id.write({"datas": old_datas, "name": old_name, "mimetype": old_mimetype})
                     self.env.cr.commit()
                     raise UserError(converted_result.get("message"))
                 if converted_result.get("fileUrl"):
@@ -75,11 +92,17 @@ class OnlyOfficeTemplate(models.Model):
                             method="get",
                         )
                         new_datas = base64.b64encode(response.content)
-                        self.attachment_id.write({"datas": new_datas})
+                        self.attachment_id.write(
+                            {
+                                "datas": new_datas,
+                                "name": self.name + ".pdf",
+                                "mimetype": file_utils.get_mime_by_ext("pdf"),
+                            }
+                        )
                         self.env.cr.commit()
                     except Exception as e:
                         logger.error("Failed to download and update PDF form: %s", str(e))
-                        self.attachment_id.write({"datas": old_datas})
+                        self.attachment_id.write({"datas": old_datas, "name": old_name, "mimetype": old_mimetype})
                         self.env.cr.commit()
                         raise UserError(_("Failed to download converted PDF form")) from e
 
@@ -142,12 +165,19 @@ class OnlyOfficeTemplate(models.Model):
                     raise UserError(_("Failed to download form")) from e
 
             is_pdf_form = None
+            src_ext = "pdf"
             if "file" in vals_copy and vals_copy["file"]:
                 try:
                     decode_file = base64.b64decode(vals_copy["file"])
                     is_pdf_form = pdf_utils.is_pdf_form(decode_file)
                 except Exception as e:
                     raise UserError(_("Invalid file format.")) from e
+                if not is_pdf_form:
+                    src_ext = pdf_utils.get_source_format(decode_file)
+                    if not src_ext:
+                        raise UserError(
+                            _("Unsupported file format. Upload a PDF form or a DOCX/XLSX/PPTX document.")
+                        )
             else:
                 vals_copy["file"] = base64.encodebytes(file_utils.get_default_file_template(self.env.user.lang, "pdf"))
                 is_pdf_form = True
@@ -171,11 +201,15 @@ class OnlyOfficeTemplate(models.Model):
                 }
             )
 
+            # While a conversion is pending the attachment must hold the *source* file
+            # (e.g. DOCX) so the document server downloads and converts the right bytes.
+            # On success it is overwritten with the resulting PDF form below.
+            src_mimetype = file_utils.get_mime_by_ext(src_ext) or "application/pdf"
             attachment = self.env["ir.attachment"].create(
                 {
-                    "name": vals_copy.get("name", record.name) + ".pdf",
+                    "name": vals_copy.get("name", record.name) + "." + src_ext,
                     "display_name": vals_copy.get("name", record.name),
-                    "mimetype": vals_copy.get("mimetype"),
+                    "mimetype": src_mimetype,
                     "datas": datas,
                     "res_model": self._name,
                     "res_id": record.id,
@@ -185,7 +219,7 @@ class OnlyOfficeTemplate(models.Model):
 
             if not is_pdf_form:
                 self.env.cr.commit()
-                converted_result = self._convert_to_form(attachment)
+                converted_result = self._convert_to_form(attachment, filetype=src_ext)
                 if converted_result.get("error"):
                     attachment.unlink()
                     record.unlink()
@@ -199,7 +233,13 @@ class OnlyOfficeTemplate(models.Model):
                             method="get",
                         )
                         new_datas = base64.b64encode(response.content)
-                        attachment.write({"datas": new_datas, "mimetype": vals_copy.get("mimetype")})
+                        attachment.write(
+                            {
+                                "datas": new_datas,
+                                "mimetype": vals_copy.get("mimetype"),
+                                "name": vals_copy.get("name", record.name) + ".pdf",
+                            }
+                        )
                         self.env.cr.commit()
                     except Exception as e:
                         logger.error("Failed to download and update PDF form: %s", str(e))
@@ -214,7 +254,7 @@ class OnlyOfficeTemplate(models.Model):
         return self.browse(results)
 
     @api.model
-    def _convert_to_form(self, attachment):
+    def _convert_to_form(self, attachment, filetype="pdf"):
         jwt_header = config_utils.get_jwt_header(self.env)
         jwt_secret = config_utils.get_jwt_secret(self.env)
         docserver_url = config_utils.get_doc_server_public_url(self.env)
@@ -234,7 +274,7 @@ class OnlyOfficeTemplate(models.Model):
         payload = {
             "url": f"{odoo_url}onlyoffice/template/download/{attachment.id}?oo_security_token={oo_security_token}",
             "key": key,
-            "filetype": "pdf",
+            "filetype": filetype or "pdf",
             "outputtype": "pdf",
             "pdf": {
                 "form": True,

--- a/onlyoffice_odoo_templates/utils/pdf_utils.py
+++ b/onlyoffice_odoo_templates/utils/pdf_utils.py
@@ -1,6 +1,42 @@
 # Copyright (C) 2026 Ascensio System SIA
 
-# TODO: add convert docx to pdf
+import io
+import zipfile
+
+# Inner files that identify an OOXML container produced by Word/Excel/PowerPoint.
+_OOXML_MARKERS = (
+    ("word/document.xml", "docx"),
+    ("xl/workbook.xml", "xlsx"),
+    ("ppt/presentation.xml", "pptx"),
+)
+
+
+def get_source_format(data):
+    """Detect the real format of an uploaded template from its bytes.
+
+    Returns one of ``"pdf"``, ``"docx"``, ``"xlsx"``, ``"pptx"`` or ``None`` when
+    the format is not recognised. The upload widget gives us no filename, so the
+    type has to be sniffed from the magic bytes.
+    """
+    if not data:
+        return None
+
+    # Regular PDF ("%PDF-") or the ONLYOFFICE form PDF marker.
+    if data[:4] == b"%PDF" or data[:6] == b"%\xcd\xca\xd2\xa9\x0d":
+        return "pdf"
+
+    # OOXML files are ZIP containers starting with the local file header "PK\x03\x04".
+    if data[:4] == b"PK\x03\x04":
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                names = set(zf.namelist())
+        except Exception:
+            return None
+        for marker, ext in _OOXML_MARKERS:
+            if marker in names:
+                return ext
+
+    return None
 
 
 def is_pdf_form(text):

--- a/onlyoffice_odoo_templates/views/onlyoffice_menu_views.xml
+++ b/onlyoffice_odoo_templates/views/onlyoffice_menu_views.xml
@@ -67,10 +67,11 @@
           </group>
           <group string="Template uploading" invisible="hide_file_field">
             <div class="text-muted" colspan="2"> If you already have a <span class="fw-bolder">prepared
-              PDF file</span> with fillable fields, you can upload it here </div>
+              PDF form</span> or a <span class="fw-bolder">DOCX/XLSX/PPTX document</span>, you can upload it
+              here. Office documents are converted to a fillable PDF on save. </div>
             <field
               name="file"
-              options="{'accepted_file_extensions': '.pdf', 'attachment': False}"
+              options="{'accepted_file_extensions': '.pdf,.docx,.xlsx,.pptx', 'attachment': False}"
               help="Select an existing template. Leave the field blank to create a blank template."
             />
           </group>


### PR DESCRIPTION
## Problem

Uploading an Office document (DOCX/XLSX/PPTX) as a template always failed. Three things blocked it:

1. **UI** — the upload widget's file picker was locked to `.pdf`, so a DOCX couldn't even be selected.
2. **Storage** — uploaded bytes were always stored as `application/pdf` named `.pdf`, regardless of the real content.
3. **Conversion** — `_convert_to_form()` hardcoded `"filetype": "pdf"`, so the document server was asked to build a PDF form out of DOCX bytes and the conversion errored (`pdf_utils` even carried a `# TODO: add convert docx to pdf`).

## Fix

- **`pdf_utils`** — new `get_source_format()` detects the real type from magic bytes (`%PDF` vs the `PK\x03\x04` OOXML zip header, peeking inside for `word/document.xml` etc.). The upload field carries no filename, so detection has to come from the bytes.
- **model** — `create()` and `_onchange_file()` now store the source file with its correct name/mimetype *while converting*, pass the real `filetype` to the converter, then overwrite the attachment with the resulting PDF form on success (rollback preserved on failure). `_convert_to_form()` takes a `filetype` argument.
- **controller** — the `download` endpoint (what the document server fetches mid-conversion) serves the attachment's real mimetype/extension instead of always `application/pdf`.
- **view** — the upload field accepts `.pdf,.docx,.xlsx,.pptx` and the helper text reflects it.

`outputtype: "pdf"` + `pdf.form: True` are unchanged, so the end result is still a fillable PDF form.

## Testing

Verified end-to-end against a local ONLYOFFICE Document Server: upload a `.docx` → it converts to a fillable PDF on save → opens in the editor. `ruff check` passes on the changed files.