### PR TITLE
[FIX] Allow report/template generation outside an HTTP request

### DIFF
--- a/onlyoffice_odoo/controllers/controllers.py
+++ b/onlyoffice_odoo/controllers/controllers.py
@@ -23,9 +23,19 @@ _logger = logging.getLogger(__name__)
 _mobile_regex = r"android|avantgo|playbook|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od|ad)|iris|kindle|lge |maemo|midp|mmp|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\\/|plucker|pocket|psp|symbian|treo|up\\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino"  # noqa: E501
 
 
-def onlyoffice_urlopen(url, timeout=120, context=None):
-    url = url_utils.replace_public_url_to_internal(request.env, url)
-    cert_verify_disabled = config_utils.get_certificate_verify_disabled(request.env)
+def _resolve_env(env):
+    # Allow callers outside of an HTTP request (shell, cron, server actions) to
+    # pass their own ``env``. Fall back to the bound request when not provided so
+    # existing controller call sites keep working unchanged.
+    if env is not None:
+        return env
+    return request.env
+
+
+def onlyoffice_urlopen(url, timeout=120, context=None, env=None):
+    env = _resolve_env(env)
+    url = url_utils.replace_public_url_to_internal(env, url)
+    cert_verify_disabled = config_utils.get_certificate_verify_disabled(env)
 
     if cert_verify_disabled and url.startswith("https://"):
         import ssl
@@ -35,10 +45,11 @@ def onlyoffice_urlopen(url, timeout=120, context=None):
     return urlopen(url, timeout=timeout, context=context)
 
 
-def onlyoffice_request(url, method, opts=None):
+def onlyoffice_request(url, method, opts=None, env=None):
+    env = _resolve_env(env)
     _logger.info("External request: %s %s", method.upper(), url)
-    url = url_utils.replace_public_url_to_internal(request.env, url)
-    cert_verify_disabled = config_utils.get_certificate_verify_disabled(request.env)
+    url = url_utils.replace_public_url_to_internal(env, url)
+    cert_verify_disabled = config_utils.get_certificate_verify_disabled(env)
     if opts is None:
         opts = {}
 

--- a/onlyoffice_odoo_templates/models/ir_actions_report.py
+++ b/onlyoffice_odoo_templates/models/ir_actions_report.py
@@ -108,7 +108,7 @@ class IrActionsReport(models.Model):
                 try:
                     templates = self.fill_template(oo_security_token, [res_id], self.onlyoffice_template_id)
                     url = next(iter(templates.values()))
-                    response = onlyoffice_request(url=quote(url, safe="/:?=&"), method="get")
+                    response = onlyoffice_request(url=quote(url, safe="/:?=&"), method="get", env=self.env)
                     if response.status_code == 200:
                         collected_streams[res_id]["stream"] = io.BytesIO(response.content)
                 except Exception as e:
@@ -253,6 +253,7 @@ class IrActionsReport(models.Model):
                         "json": docbuilder_payload,
                         "headers": docbuilder_headers,
                     },
+                    env=self.env,
                 )
             else:
                 docbuilder_response = onlyoffice_request(
@@ -261,6 +262,7 @@ class IrActionsReport(models.Model):
                     opts={
                         "json": docbuilder_payload,
                     },
+                    env=self.env,
                 )
             docbuilder_json = docbuilder_response.json()
             if docbuilder_json.get("error"):

--- a/onlyoffice_odoo_templates/models/onlyoffice_odoo_templates.py
+++ b/onlyoffice_odoo_templates/models/onlyoffice_odoo_templates.py
@@ -73,6 +73,7 @@ class OnlyOfficeTemplate(models.Model):
                         response = onlyoffice_request(
                             url=converted_result["fileUrl"],
                             method="get",
+                            env=self.env,
                         )
                         new_datas = base64.b64encode(response.content)
                         self.attachment_id.write({"datas": new_datas})
@@ -134,6 +135,7 @@ class OnlyOfficeTemplate(models.Model):
                     response = onlyoffice_request(
                         url=url,
                         method="get",
+                        env=self.env,
                     )
 
                     file_content = response.content
@@ -197,6 +199,7 @@ class OnlyOfficeTemplate(models.Model):
                         response = onlyoffice_request(
                             url=converted_result["fileUrl"],
                             method="get",
+                            env=self.env,
                         )
                         new_datas = base64.b64encode(response.content)
                         attachment.write({"datas": new_datas, "mimetype": vals_copy.get("mimetype")})
@@ -260,6 +263,7 @@ class OnlyOfficeTemplate(models.Model):
                     "data": json.dumps(payload),
                     "headers": headers,
                 },
+                env=self.env,
             )
             if response.status_code == 200:
                 response_json = response.json()


### PR DESCRIPTION
## Problem

`onlyoffice_request()` and `onlyoffice_urlopen()` in `onlyoffice_odoo/controllers/controllers.py` read `request.env` directly. `request` is a werkzeug local proxy that is only bound during an HTTP request, so any code path that triggers ONLYOFFICE report/template generation **outside** of a web request fails with:

```
RuntimeError: object is not bound
```

This happens when generating an ONLYOFFICE-backed report from:
- the Odoo shell,
- an `ir.cron` job,
- a server action / automated action,
- mail template rendering driven from any of the above.

A real-world trigger is sending a `mail.template` whose report attachment is an ONLYOFFICE template, from a scheduled/cron context.

## Fix

Add an optional `env` parameter to both helpers, resolved through a small `_resolve_env(env)` that falls back to `request.env` when nothing is passed. Model-layer callers (`ir_actions_report` and `onlyoffice_odoo_templates`) now pass `env=self.env`.

This is fully backward compatible: every existing controller call site (where `request` is bound) passes nothing and behaves exactly as before.

## Changes

- `onlyoffice_odoo`: `onlyoffice_request`/`onlyoffice_urlopen` accept `env=None` (falls back to `request.env`).
- `onlyoffice_odoo_templates`: pass `env=self.env` at the model-layer call sites (report stream fetch, `fill_template` docbuilder posts, template conversion/create paths).

`ruff check` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)