### PR TITLE
fix: replace remaining deprecated @route(type='json') with type='jsonrpc'

### DIFF
--- a/onlyoffice_odoo_templates/controllers/controllers.py
+++ b/onlyoffice_odoo_templates/controllers/controllers.py
@@ -521,14 +521,14 @@ class OnlyofficeTemplate_Connector(http.Controller):
         logger.info("get_user_from_token - user: %s", user.name)
         return user
 
-    @http.route("/onlyoffice/template/documents/check", auth="user", type="json")
+    @http.route("/onlyoffice/template/documents/check", auth="user", type="jsonrpc")
     def check_documents_module(self):
         """Check if the documents module is installed."""
         return bool(
             request.env["ir.module.module"].sudo().search([("name", "=", "documents"), ("state", "=", "installed")])
         )
 
-    @http.route("/onlyoffice/template/documents/folders", auth="user", type="json")
+    @http.route("/onlyoffice/template/documents/folders", auth="user", type="jsonrpc")
     def get_documents_folders(self):
         """Get folders available to the current user from the Documents module."""
         try:
@@ -553,7 +553,7 @@ class OnlyofficeTemplate_Connector(http.Controller):
         result.sort(key=lambda f: f["display_name"])
         return result
 
-    @http.route("/onlyoffice/template/documents/save", auth="user", type="json")
+    @http.route("/onlyoffice/template/documents/save", auth="user", type="jsonrpc")
     def save_to_documents(self, template_id, record_ids, folder_id):
         """Fill template and save the result to the specified Documents folder."""
         logger.info(


### PR DESCRIPTION
## Summary

- Replace the last three `@route(type='json')` decorators with `type='jsonrpc'` in `onlyoffice_odoo_templates`
  - Since Odoo 19.0, `type='json'` is a deprecated alias for `type='jsonrpc'` and logs a `DeprecationWarning` when the module is loaded
  - Completes the migration started in #105 — these three routes were added afterwards (in the "save filled template to documents" feature) and still used the old spelling
- Resolves the warning reported in #85

## Files changed

- `onlyoffice_odoo_templates/controllers/controllers.py`

## Notes

No behaviour change: Odoo 19 rewrites `type='json'` to `'jsonrpc'` internally and dispatches both through the same `JsonRPCDispatcher`, so the request/response format is identical. The three JS callers use `rpc()` from `@web/core/network/rpc` and need no changes.