### PR TITLE
[FIX] Cap the generated document's file name

### DIFF
--- a/CHANGELOG templates.md
+++ b/CHANGELOG templates.md
@@ -5,6 +5,7 @@
 ## Fixed
 
 - cache template form field keys when loading/editing a template
+- cap the generated document's file name so a long record name cannot fail the build
 
 ## 4.5.2
 

--- a/onlyoffice_odoo_templates/controllers/controllers.py
+++ b/onlyoffice_odoo_templates/controllers/controllers.py
@@ -239,6 +239,13 @@ class OnlyofficeTemplate_Connector(http.Controller):
                 record_name = getattr(record, "display_name", getattr(record, "name", str(record_id)))
                 template_name = getattr(template, "display_name", getattr(template, "name", "Filled Template"))
                 filename = re.sub(r"[<>:'/\\|?*\x00-\x1f]", " ", f"{template_name} - {record_name}")
+                # A record's display name can be a paragraph, and the name built from
+                # it then overruns the filesystem's 255-byte limit. The Document
+                # Server fails to save the file and reports only "Document generation
+                # error", which points nowhere near the cause: the same template
+                # renders fine for a record with a shorter name, and the same record
+                # fails on every template.
+                filename = " ".join(filename.split())[:120].strip()
 
                 editable_form_fields = templates_config_utils.get_editable_form_fields(http.request.env)
                 if editable_form_fields:


### PR DESCRIPTION
## Problem

The filled document's name is built from the template and the record:

```python
filename = re.sub(r"[<>:'/\\|?*\x00-\x1f]", " ", f"{template_name} - {record_name}")
```

Illegal characters are replaced, but the length is never bounded — and a record's `display_name` can be a paragraph. A contract line carrying a whole service description produces a name of some 400 characters, against the 255-byte limit filesystems impose.

The Document Server then fails to save the file and reports only:

```
Document generation error
```

which points nowhere near the cause. The symptom is confusing in both directions: the same template renders perfectly for a record with a shorter name, and the same record fails on every template, so it reads like a template problem or an intermittent server problem rather than a name-length one.

## Change

Collapse whitespace and cap the name at 120 characters, leaving room for the extension and any suffix added downstream.

## Testing

Found on a real agenda of 56 contract-document templates: two documents could not be printed at all, and any record with a long display name would have hit the same wall. With the cap, all 56 render. Running in production on an 18.0 deployment since.

`ruff check` passes on the changed file.